### PR TITLE
Add backend-independent access to cookiejar

### DIFF
--- a/oslo_vmware/exceptions.py
+++ b/oslo_vmware/exceptions.py
@@ -297,9 +297,10 @@ def get_fault_class(name):
 
 
 def translate_fault(localized_method_fault, excep_msg=None):
-    """Produce proper VimException subclass object based on a vmodl.LocalizedMethodFault.
-    
-    :param excep_msg: Message to set to the exception. Defaults to localizedMessage of the fault.
+    """Produce VimException subclass based on a vmodl.LocalizedMethodFault.
+
+    :param excep_msg: Message to set to the exception. Defaults to
+                      localizedMessage of the fault.
     """
     try:
         if not excep_msg:
@@ -311,7 +312,8 @@ def translate_fault(localized_method_fault, excep_msg=None):
         else:
             ex = VimFaultException([name], excep_msg)
     except Exception as e:
-        LOG.debug("Unexpected exception thrown (%s) while translating fault (%s) with message: %s.",
+        LOG.debug("Unexpected exception thrown (%s) while translating fault "
+                  "(%s) with message: %s.",
                   e, localized_method_fault, excep_msg)
         ex = VimException(message=excep_msg, cause=e)
 

--- a/oslo_vmware/rw_handles.py
+++ b/oslo_vmware/rw_handles.py
@@ -500,7 +500,7 @@ class VmdkWriteHandle(VmdkHandle):
         url, thumbprint = self._find_vmdk_url(lease_info, host, port)
         self._vm_ref = lease_info.entity
 
-        cookies = session.vim.client.options.transport.cookiejar
+        cookies = session.vim.client.cookiejar
         # Create HTTP connection to write to VMDK URL
         if http_method == 'PUT':
             overwrite = 't'
@@ -604,7 +604,7 @@ class VmdkReadHandle(VmdkHandle):
 
         # find URL of the VMDK file to be read and open connection
         url, thumbprint = self._find_vmdk_url(lease_info, host, port)
-        cookies = session.vim.client.options.transport.cookiejar
+        cookies = session.vim.client.cookiejar
         self._conn = self._create_read_connection(url,
                                                   cookies=cookies,
                                                   ssl_thumbprint=thumbprint)

--- a/oslo_vmware/rw_handles.py
+++ b/oslo_vmware/rw_handles.py
@@ -33,9 +33,9 @@ import six.moves.urllib.parse as urlparse
 from urllib3 import connection as httplib
 
 from oslo_vmware._i18n import _
+from oslo_vmware.common import loopingcall
 from oslo_vmware import exceptions
 from oslo_vmware import vim_util
-from oslo_vmware.common import loopingcall
 
 
 LOG = logging.getLogger(__name__)

--- a/oslo_vmware/tests/test_pbm.py
+++ b/oslo_vmware/tests/test_pbm.py
@@ -24,8 +24,8 @@ import six.moves.urllib.parse as urlparse
 import six.moves.urllib.request as urllib
 
 from oslo_vmware import pbm
-from oslo_vmware import vim_util
 from oslo_vmware.tests import base
+from oslo_vmware import vim_util
 
 
 class PBMUtilityTest(base.TestCase):

--- a/oslo_vmware/tests/test_rw_handles.py
+++ b/oslo_vmware/tests/test_rw_handles.py
@@ -198,7 +198,7 @@ class VmdkWriteHandleTest(base.TestCase):
         vim_cookie = mock.Mock()
         vim_cookie.name = 'name'
         vim_cookie.value = 'value'
-        session.vim.client.options.transport.cookiejar = [vim_cookie]
+        session.vim.client.cookiejar = [vim_cookie]
         return session
 
     def test_init_failure(self):
@@ -299,7 +299,7 @@ class VmdkReadHandleTest(base.TestCase):
         vim_cookie = mock.Mock()
         vim_cookie.name = 'name'
         vim_cookie.value = 'value'
-        session.vim.client.options.transport.cookiejar = [vim_cookie]
+        session.vim.client.cookiejar = [vim_cookie]
         return session
 
     def test_init_failure(self):

--- a/oslo_vmware/tests/test_service.py
+++ b/oslo_vmware/tests/test_service.py
@@ -58,7 +58,7 @@ class ServiceTest(base.TestCase):
 
     def setUp(self):
         super(ServiceTest, self).setUp()
-        patcher = mock.patch('suds.client.Client')
+        patcher = mock.patch('oslo_vmware.service.CompatibilitySudsClient')
         self.addCleanup(patcher.stop)
         self.SudsClientMock = patcher.start()
 
@@ -373,7 +373,7 @@ class ServiceTest(base.TestCase):
         cookie = mock.Mock()
         cookie.name = 'vmware_soap_session'
         cookie.value = cookie_value
-        svc_obj.client.options.transport.cookiejar = [cookie]
+        svc_obj.client.cookiejar = [cookie]
         self.assertEqual(cookie_value, svc_obj.get_http_cookie())
 
     def test_get_session_cookie_with_no_cookie(self):
@@ -381,7 +381,7 @@ class ServiceTest(base.TestCase):
         cookie = mock.Mock()
         cookie.name = 'cookie'
         cookie.value = 'xyz'
-        svc_obj.client.options.transport.cookiejar = [cookie]
+        svc_obj.client.cookiejar = [cookie]
         self.assertIsNone(svc_obj.get_http_cookie())
 
     def test_set_soap_headers(self):

--- a/oslo_vmware/tests/test_vim.py
+++ b/oslo_vmware/tests/test_vim.py
@@ -33,7 +33,7 @@ class VimTest(base.TestCase):
 
     def setUp(self):
         super(VimTest, self).setUp()
-        patcher = mock.patch('suds.client.Client')
+        patcher = mock.patch('oslo_vmware.service.CompatibilitySudsClient')
         self.addCleanup(patcher.stop)
         self.SudsClientMock = patcher.start()
         self.useFixture(i18n_fixture.ToggleLazy(True))

--- a/oslo_vmware/vim_util.py
+++ b/oslo_vmware/vim_util.py
@@ -23,7 +23,7 @@ from oslo_utils import timeutils
 from suds import sudsobject
 
 try:
-    import suds.eventlet_patch
+    import suds.eventlet_patch  # noqa
 except ImportError:
     pass
 


### PR DESCRIPTION
Having the cookiejar available as attribute on the client instead of
some child objects exposes an interface depending code can rely on. This
will help with upcoming efforts to switch the SOAP library backing
oslo.vmware.

Change-Id: I72082f10a184a2451dfda3d002a9288fefcef961