### PR TITLE
[SAP] Backport: Fix object has no attribute 'readinto' in Python3

### DIFF
--- a/oslo_vmware/service.py
+++ b/oslo_vmware/service.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2014 VMware, Inc.
+# Copyright (c) 2014-2020 VMware, Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -18,7 +18,6 @@ Common classes that provide access to vSphere services.
 """
 
 import logging
-import os
 
 import netaddr
 from oslo_utils import timeutils
@@ -150,9 +149,9 @@ class LocalFileAdapter(requests.adapters.HTTPAdapter):
 
     def _build_response_from_file(self, request):
         file_path = request.url[7:]
-        with open(file_path, 'r') as f:
-            buff = bytearray(os.path.getsize(file_path))
-            f.readinto(buff)
+        with open(file_path, 'rb') as f:
+            file_content = f.read()
+            buff = bytearray(file_content.decode(), "utf-8")
             resp = Response(buff)
             return self.build_response(request, resp)
 

--- a/oslo_vmware/tests/test_service.py
+++ b/oslo_vmware/tests/test_service.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2014 VMware, Inc.
+# Copyright (c) 2014-2020 VMware, Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -500,8 +500,8 @@ class RequestsTransportTest(base.TestCase):
         data = b"Hello World"
         get_size_mock.return_value = len(data)
 
-        def readinto_mock(buf):
-            buf[0:] = data
+        def read_mock():
+            return data
 
         if six.PY3:
             builtin_open = 'builtins.open'
@@ -515,7 +515,7 @@ class RequestsTransportTest(base.TestCase):
         file_handle = mock.MagicMock(spec=file_spec)
         file_handle.write.return_value = None
         file_handle.__enter__.return_value = file_handle
-        file_handle.readinto.side_effect = readinto_mock
+        file_handle.read.side_effect = read_mock
         open_mock.return_value = file_handle
 
         with mock.patch(builtin_open, open_mock, create=True):


### PR DESCRIPTION
File Object in Python3 do not have readinfo function.

Change-Id: Ifcda45d7641b895a58472a533655ca4d3f33f246