### PR TITLE
Set purge_props=False in upload_image

### DIFF
--- a/oslo_vmware/image_transfer.py
+++ b/oslo_vmware/image_transfer.py
@@ -325,7 +325,7 @@ def upload_image(context, timeout_secs, image_service, image_id, owner_id,
     try:
         updater.start(interval=NFC_LEASE_UPDATE_PERIOD)
         image_service.update(context, image_id, image_metadata,
-                             data=read_handle)
+                             data=read_handle, purge_props=False)
     finally:
         updater.stop()
         read_handle.close()

--- a/oslo_vmware/tests/test_image_transfer.py
+++ b/oslo_vmware/tests/test_image_transfer.py
@@ -400,4 +400,5 @@ class ImageTransferUtilityTest(base.TestCase):
         image_service.update.assert_called_once_with(context,
                                                      image_id,
                                                      image_metadata,
-                                                     data=fake_VmdkReadHandle)
+                                                     data=fake_VmdkReadHandle,
+                                                     purge_props=False)


### PR DESCRIPTION
The image_service passed by the caller purges the existing image
properties by default [1]. Our goal here is to update the
properties we care about, without affecting any existing properties
of the image, thus, we will set purge_props=False.

[1] https://github.com/openstack/cinder/blob/4f68296d67e81c7f73980cbd6de4a8f912d60ce4/cinder/image/glance.py#L396