### PR TITLE
[SAP] Replace suds-jurko with suds-community

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ oslo.utils>=3.33.0 # Apache-2.0
 PyYAML>=3.12 # MIT
 
 lxml!=3.7.0,>=3.4.1 # BSD
-suds-jurko>=0.6 # LGPLv3+
+suds-community>=0.6 # LGPLv3+
 eventlet!=0.18.3,!=0.20.1,>=0.18.2 # MIT
 requests>=2.14.2 # Apache-2.0
 urllib3>=1.21.1 # MIT

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -14,6 +14,6 @@ stestr>=2.0.0 # Apache-2.0
 #  [testenv:cover]
 #  deps = {[testenv]deps} coverage
 coverage!=4.4,>=4.0 # Apache-2.0
-bandit>=1.1.0 # Apache-2.0
+bandit>=1.1.0,<1.6.3 # Apache-2.0
 ddt>=1.0.1 # MIT
 oslo.context>=2.19.2 # Apache-2.0


### PR DESCRIPTION
suds-jurko is not compatible with setuptools >58.0.0 and has not been
maintained for a long time. Let's use suds-community instead.

Related-Bug: 1946340
Depends-On: I4eb235c3ad0f1296fc81a9b98d7e687ac9923b59
Change-Id: Ie3f317974d138be4050d0ce196bcc000494a0eee

cherry-picked from upstream
7bc343173751330d2e989c28bc6fefed56d358d6

https://github.com/openstack/oslo.vmware/commit/7bc343173751330d2e989c28bc6fefed56d358d6