### PR TITLE
Fix json-serialisation of datetime

### DIFF
--- a/oslo_vmware/_monkeypatch.py
+++ b/oslo_vmware/_monkeypatch.py
@@ -22,7 +22,8 @@ from oslo_vmware import vim_util
 class _JsonPrinter(object):
     def tostr(self, obj, indent=-2):
         """Get s string representation of object."""
-        return json.dumps(vim_util.serialize_object(obj))
+        return json.dumps(vim_util.serialize_object(obj),
+                          default=str)
 
 
 suds.sudsobject.Printer = _JsonPrinter


### PR DESCRIPTION
The default json encoder cannot serialse datetime,
but we get them from vim_util.serialize_object