### PR TITLE
Added Deserialize and compatible Serialize

### DIFF
--- a/oslo_vmware/tests/test_vim_util.py
+++ b/oslo_vmware/tests/test_vim_util.py
@@ -20,9 +20,135 @@ Unit tests for VMware API utility module.
 import collections
 
 import mock
+import six
 
 from oslo_vmware.tests import base
 from oslo_vmware import vim_util
+
+
+class FakeSXTypeDesc(object):
+    def __init__(self, name, type):
+        self.name = name
+        self.type = [type]
+
+
+class FakeSXType(object):
+    def __init__(self, name, children):
+        self.name = name
+        self._children = [
+            FakeSXTypeDesc(k, v) for k, v in six.iteritems(children)
+        ]
+
+    def get_child(self, name):
+        for child in self._children:
+            if child.name == name:
+                return child, None
+        print([(child.name, child.type[0]) for child in self._children])
+        raise ValueError(
+            "Didn't expect child by name '{}' in '{}'".format(name, self.name))
+
+    def children(self):
+        for child in self._children:
+            yield child, None
+
+    def __eq__(self, other):
+        return self.name == other.name
+
+
+class FakeObject(object):
+    DEFAULT_TYPE = "Class"
+
+    def __init__(self, type=None, **members):
+        sxtype = FakeFactory.find(type or FakeObject.DEFAULT_TYPE)
+        if not sxtype:
+            raise ValueError("Unknown type {}".format(type))
+        self.__metadata__ = dict(sxtype=sxtype)
+        self.__keylist__ = []
+        for k, v in six.iteritems(members):
+            setattr(self, k, v)
+
+    def __setattr__(self, name, value):
+        if not name.startswith("__") and name not in self.__keylist__:
+            self.__keylist__.append(name)
+        self.__dict__[name] = value
+
+    def __iter__(self):
+        for key in self.__keylist__:
+            yield key, getattr(self, key)
+
+    def __str__(self):
+        sxtype = self.__metadata__['sxtype']
+        return "{}({})".format(
+            sxtype.name,
+            ", ".join("{}={!r}".format(k, getattr(self, k))
+                      for k in self.__keylist__
+                      if getattr(self, k) is not None))
+
+    def __repr__(self):
+        return str(self)
+
+    def __eq__(self, other):
+        own_type = self.__metadata__['sxtype']
+        other_type = other.__metadata__['sxtype']
+        if own_type != other_type:
+            return False
+
+        keylist = set(self.__keylist__) | set(other.__keylist__)
+        for key in keylist:
+            own_value = getattr(self, key, None)
+            other_value = getattr(other, key, None)
+            if own_value != other_value:
+                return False
+
+        return True
+
+    def __ne__(self, other):
+        return not (self == other)
+
+
+class FakeFactory(object):
+    __TYPES = {}
+
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def create(qname):
+        return FakeObject(qname.split(':')[-1])
+
+    @property
+    def resolver(self):
+        return self
+
+    @classmethod
+    def _get_registry(cls):
+        if cls.__TYPES:
+            return cls.__TYPES
+
+        children = dict(
+            a=None,
+            i=None,
+            n=None,
+            none=None,
+            l=None,
+            s=None,
+            t=None,
+            f=None,
+            child="Class",
+            children="Class",
+            z=None,
+        )
+        class_ = FakeSXType("Class", children)
+        otherclass = FakeSXType("OtherClass", children)
+        cls.__TYPES["Class"] = class_
+        cls.__TYPES["OtherClass"] = otherclass
+        return cls.__TYPES
+
+    @staticmethod
+    def find(qname):
+        sname = qname.split(':')[-1]
+        registry = FakeFactory._get_registry()
+        return registry.get(sname)
 
 
 class VimUtilTest(base.TestCase):
@@ -535,3 +661,54 @@ class VimUtilTest(base.TestCase):
         self.assertEqual({"test_name_0": "test_val_0",
                           "test_name_1": "test_val_1"},
                          vim_util.propset_dict(mock_propset))
+
+    def test_serialize_object_managed_object_none(self):
+        class_ = mock.NonCallableMagicMock(__name__="ManagedObjectReference")
+        obj = mock.NonCallableMagicMock(value=None, __class__=class_)
+        self.assertEqual(None, vim_util.serialize_object(obj))
+
+    @staticmethod
+    def _deserialize_test_fixtures():
+        return [
+            ("Empty default class",
+             {},
+             FakeObject()),
+            ("Empty derived class",
+             {"class": "OtherClass"},
+             FakeObject("OtherClass")),
+            ("Do not drop non-defaults",
+             {'a': 'A', 'n': 0, 'i': 1, 's': "", 't': True, 'f': False,
+              'child': {'class': 'OtherClass'}, 'z': 'Z'},
+             FakeObject(a='A', n=0, i=1, s="", t=True, f=False,
+                        child=FakeObject("OtherClass"),
+                        z='Z')),
+            ("Nested object",
+             {'child': {'n': 1}, 'n': 0, },
+             FakeObject(n=0, child=FakeObject(n=1)),),
+            ("Nested object list",
+             {'children': [{'n': 1}], 'n': 0, },
+             FakeObject(n=0, children=[FakeObject(n=1)])),
+            ("Nested derived class",
+             {'child': {"class": "OtherClass", 'n': 1}, 'n': 0, },
+             FakeObject(n=0, child=FakeObject("OtherClass", n=1)),),
+            ("Nested derived class list",
+             {'children': [{"class": "OtherClass", 'n': 1}], 'n': 0, },
+             FakeObject(n=0, children=[FakeObject("OtherClass", n=1)]))]
+
+    @staticmethod
+    def _serialize_test_fixtures():
+        return VimUtilTest._deserialize_test_fixtures() + [
+            ("Drop default",
+             {'a': 'A', 'z': 'Z', },
+             FakeObject(a='A', none=None, l=[], child=FakeObject(), z='Z'))]
+
+    def test_serialize(self):
+        for msg, d, obj in self._serialize_test_fixtures():
+            ser = vim_util.serialize_object(obj, True, FakeObject.DEFAULT_TYPE)
+            self.assertEqual(d, ser, msg)
+
+    def test_deserialize(self):
+        cf = FakeFactory()
+        for msg, d, obj in self._deserialize_test_fixtures():
+            res = vim_util.deserialize_object(cf, d, FakeObject.DEFAULT_TYPE)
+            self.assertEqual(obj, res, msg)

--- a/oslo_vmware/vim_util.py
+++ b/oslo_vmware/vim_util.py
@@ -679,22 +679,126 @@ def is_vim_instance(o, vim_type_name):
                                                      sudsobject.Object))
 
 
-def serialize_object(obj):
-    """Convert Suds object into a dict."""
+def _get_child_type(sxtype, name):
+    if not sxtype:
+        return None
+    child, _ = sxtype.get_child(name)
+    return child.type[0]
+
+
+def serialize_object(obj, typed=False, expected_type=None):
+    """Serialize a SOAP object to a dict
+
+    For the function to serialize it in a format that the corresponding
+    deserialize_object can restore the original object, it needs to get
+    passed typed=True.
+
+    Additionally, if the argument is potentially derived from
+    some other type, then also expected_type as string:
+    If the object is of such a derived class, it adds the "class" field with
+    the name of the class to the dict.
+    That way, the deserializer can reconstruct the correct type.
+    This also applies to member variables of the passed object.
+
+    Any empty object/list/dictionary will not be serialized
+    :param obj:   The SOAP object to be serialized
+    :param typed: Required for deserializing polymorph objects.
+                  Should the resulting dict be annotated with field "class",
+                  if the actual class does not match expected_type
+    :param expected_type: The expected type name (without namespace) of the
+                  argument passed as "obj".
+    :return:      dictionary representing the serialized object without empty
+                  default values
+    """
+    if obj is None:
+        return None
+
+    if (obj.__class__.__name__ == 'ManagedObjectReference' and
+            not obj.value):
+        # Special case for suds, which creates "empty" references
+        # as a value object with an empty string
+        return None
+
     d = {}
+    if not typed or "sxtype" not in obj.__metadata__:
+        sxtype = None
+    else:
+        sxtype = obj.__metadata__["sxtype"]
+        if expected_type and sxtype.name != expected_type:
+            d["class"] = sxtype.name
+
     for k, v in dict(obj).items():
-        if hasattr(v, '__keylist__'):
-            d[k] = serialize_object(v)
-        elif isinstance(v, list):
-            d[k] = []
+        if hasattr(v, "__keylist__"):
+            expected_type = _get_child_type(sxtype, k)
+            ser = serialize_object(v, typed=typed, expected_type=expected_type)
+            if not typed or ser:
+                d[k] = ser
+        elif isinstance(v, list):  # dicts are simply objects
+            expected_type = _get_child_type(sxtype, k)
+            ser = []
             for item in v:
-                if hasattr(item, '__keylist__'):
-                    d[k].append(serialize_object(item))
+                if hasattr(item, "__keylist__"):
+                    ser.append(
+                        serialize_object(item, typed=typed,
+                                         expected_type=expected_type))
                 else:
-                    d[k].append(item)
+                    ser.append(item)
+            if not typed or ser:
+                d[k] = ser
         else:
-            d[k] = v
+            if not typed or v is not None:
+                d[k] = v
     return d
+
+
+def deserialize_object(factory, serialized, typename):
+    """"Deserialize a dict to a SOAP object
+
+    :param factory: The client factory to create a SOAP object out of name
+                    (vim.client.factory)
+    :param serialized: The dict containing the serialized object
+    :param typename: A string with the name of the expected type of the object
+                     (without namespace)
+    """
+    if serialized is None:
+        return serialized
+
+    if typename == "ManagedObjectReference":
+        # Special case: It is a simpleContent object (the only in the wsdl)
+        return get_moref(serialized["value"], serialized["_type"])
+
+    typename = serialized.get("class", typename)
+    qtypename = "ns0:{}".format(typename)
+    obj = factory.create(qtypename)
+    try:
+        sxtype = obj.__metadata__["sxtype"]
+    except AttributeError:
+        sxtype = factory.resolver.find(qtypename)
+
+    # We are iterating here over all children instead of all elements
+    # in the dict, because the factory method from suds above creates
+    # an "empty" object for an optional value, which is not rendered
+    # back to an empty value in the request.
+    # By setting all the unset values explicitly to None, we work around
+    # that
+    for child, _ in sxtype.children():
+        v = serialized.get(child.name, None)
+
+        if isinstance(v, list):
+            if not v or not isinstance(v[0], dict):
+                deserialized = v
+            else:
+                type_ = child.type[0]
+                deserialized = [deserialize_object(factory, i, type_)
+                                for i in v]
+        elif isinstance(v, dict):
+            type_ = child.type[0]
+            deserialized = deserialize_object(factory, v, type_)
+        else:
+            deserialized = v
+
+        setattr(obj, child.name, deserialized)
+    return obj
 
 
 def storage_placement_spec(client_factory,


### PR DESCRIPTION
To transport SOAP objects over other transport mechanisms,
such as oslo.messaging, we need a representation,
which allows us to reconstruct (de-serialize) the
serialized object. This is commonly a dict, as done in
the pre-existing serialize_object function.

This change improves the function by:
1. Not serializing empty defaults making the result
   less verbose
2. Serialize the type by adding the "class" field to
   the dict, in cases of fields being of derived types
   of the default

For compatibility reasons, the latter is only active
when opting-in.

Additionally, the deserialize_object has been added,
which takes the dict generated by serialize_object
and creates a SOAP object out of it

Change-Id: Ie76b1e6940b5022563ce91d5692df589573704d0