### PR TITLE
Use new typed format for logging

### DIFF
--- a/oslo_vmware/_monkeypatch.py
+++ b/oslo_vmware/_monkeypatch.py
@@ -22,7 +22,7 @@ from oslo_vmware import vim_util
 class _JsonPrinter(object):
     def tostr(self, obj, indent=-2):
         """Get s string representation of object."""
-        return json.dumps(vim_util.serialize_object(obj),
+        return json.dumps(vim_util.serialize_object(obj, True),
                           default=str)
 
 


### PR DESCRIPTION
The new json format resolves some ambiguity by
printing the name of a class in case of polymorphism
and in some cases the type of the class it he only information
provided.
Also the format is more compact by leaving out all the empty
defaults

Change-Id: I5321a9e7a180b954b1cd963d2d17b92d6cb6d410