### PR TITLE
[rocky] Pull images from Swift URL

### DIFF
--- a/oslo_vmware/image_transfer.py
+++ b/oslo_vmware/image_transfer.py
@@ -243,6 +243,23 @@ def download_stream_optimized_image(context, timeout_secs, image_service,
               {'id': image_id,
                'container': container_format})
 
+    allow_pull_from_url = kwargs.get('allow_pull_from_url', False)
+    url_handle = None
+
+    if allow_pull_from_url and container_format == 'bare':
+        (direct_url, locations) = image_service.get_location(context, image_id)
+        try:
+            url_handle = rw_handles.SwiftUrlPullHandle(
+                direct_url, context.get_auth_plugin().auth_token)
+        except ValueError as e:
+            LOG.debug(e)
+
+    if url_handle:
+        imported_vm = image_pull_from_url(url_handle, **kwargs)
+        LOG.debug("Downloaded image: %s from image direct URL as a stream "
+                  "optimized file.")
+        return imported_vm
+
     # TODO(vbala) catch specific exceptions raised by download call
     read_iter = image_service.download(context, image_id)
     read_handle = rw_handles.ImageReadHandle(read_iter)
@@ -340,3 +357,59 @@ def upload_image(context, timeout_secs, image_service, image_id, owner_id,
         updater.stop()
         read_handle.close()
     LOG.debug("Uploaded image: %s.", image_id)
+
+
+def image_pull_from_url(url_handle, **kwargs):
+    """Converts a lease to pull from URLs and waits for the import.
+    Using HttpNfcLeasePullFromUrls_Task
+    """
+    session = kwargs.get('session')
+    size = kwargs.get('image_size')
+
+    (lease, lease_info) = \
+        rw_handles.VmdkHandle._create_import_vapp_lease(
+            kwargs.get('session'), kwargs.get('resource_pool'),
+            kwargs.get('vm_import_spec'), kwargs.get('vm_folder'))
+
+    try:
+        return upgrade_lease_to_pull_mode(
+            session, lease, lease_info, url_handle, size)
+    finally:
+        session.invoke_api(session.vim,
+                           'HttpNfcLeaseComplete',
+                           lease)
+
+
+def upgrade_lease_to_pull_mode(session, lease, lease_info, url_handle, size):
+    if not lease_info.deviceUrl:
+        raise Exception("Invalid HttpNfc lease. "
+                        "No DeviceURLs found to import to.")
+
+    import_key = lease_info.deviceUrl[0].importKey
+
+    client_factory = session.vim.client.factory
+    file_spec = client_factory.create("ns0:HttpNfcLeaseSourceFile")
+    file_spec.targetDeviceId = import_key
+    file_spec.url = url_handle.url()
+    file_spec.create = True
+    file_spec.sslThumbprint = url_handle.ssl_thumbprint()
+    if size:
+        file_spec.size = size
+    headers = url_handle.headers()
+    if headers:
+        file_spec.httpHeaders = vim_util.dict_to_kv(client_factory,
+                                                    headers)
+    pull_task = session.invoke_api(session.vim,
+                                   "HttpNfcLeasePullFromUrls_Task",
+                                   lease,
+                                   files=[file_spec])
+
+    LOG.debug("Started pulling the image from URL %(url)s",
+              {'url': url_handle.url()})
+
+    session.wait_for_task(pull_task)
+
+    LOG.debug("Completed pulling the image from URL %(url)s",
+              {'url': url_handle.url()})
+
+    return lease_info.entity

--- a/oslo_vmware/rw_handles.py
+++ b/oslo_vmware/rw_handles.py
@@ -22,6 +22,7 @@ glance server.
 """
 
 import logging
+import OpenSSL
 import ssl
 import time
 
@@ -719,3 +720,50 @@ class ImageReadHandle(object):
 
     def __str__(self):
         return "Image read handle"
+
+
+class UrlPullHandle(object):
+    """Base class for a URL from where VMware can download VMDKs
+
+    This kind of handles are being used in conjunction with
+    HttpNfcLeasePullFromUrls_Task, converting an existing lease
+    to "Pull" mode.
+    """
+
+    def url(self):
+        """Returns the URL to the VMDK."""
+        raise NotImplementedError()
+
+    def headers(self):
+        """Optional headers that can be set on the request."""
+        return {}
+
+    def ssl_thumbprint(self):
+        # Find SSL Thumbprint of the Swift endpoint, needed by VMWare
+        urlinfo = urlparse.urlparse(self.url())
+        cert = ssl.get_server_certificate((urlinfo.hostname,
+                                           urlinfo.port or 443))
+        x509 = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM,
+                                               cert)
+        return x509.digest("sha1")
+
+
+class SwiftUrlPullHandle(UrlPullHandle):
+
+    SWIFT_PREFIX = "swift+"
+
+    def __init__(self, direct_url, auth_token):
+        super(SwiftUrlPullHandle, self).__init__()
+        self._auth_token = auth_token
+        self._url = None
+
+        if direct_url and direct_url.startswith(self.SWIFT_PREFIX):
+            self._url = direct_url.replace(self.SWIFT_PREFIX, "")
+        else:
+            raise ValueError("The provided URL is not from swift.")
+
+    def url(self):
+        return self._url
+
+    def headers(self):
+        return {'X-Auth-Token': self._auth_token}

--- a/oslo_vmware/tests/test_image_transfer.py
+++ b/oslo_vmware/tests/test_image_transfer.py
@@ -313,6 +313,35 @@ class ImageTransferUtilityTest(base.TestCase):
         self._test_download_stream_optimized_image(container='ova',
                                                    invalid_ova=True)
 
+    @mock.patch.object(image_transfer, 'image_pull_from_url')
+    def test_download_stream_optimized_image_from_swift(self, mock_img_pull):
+        image_service = mock.Mock()
+        context = mock.Mock()
+        context.get_auth_plugin.return_value = mock.Mock(
+            auth_token=mock.sentinel.auth_token)
+        timeout_secs = mock.sentinel.timeout_secs
+        image_id = mock.sentinel.image_id
+        session = mock.sentinel.session
+
+        image_service.show.return_value = {'container_format': 'bare'}
+        image_service.download.return_value = mock.Mock()
+        image_service.get_location.return_value = ('swift+https://example.com',
+                                                   [])
+        mock_img_pull.return_value = 'fake-url-ref'
+
+        kwargs = {'session': session,
+                  'allow_pull_from_url': True}
+
+        imported_vm = image_transfer.download_stream_optimized_image(
+            context,
+            timeout_secs,
+            image_service,
+            image_id,
+            **kwargs)
+
+        self.assertEqual('fake-url-ref', imported_vm)
+        self.assertEqual(1, len(mock_img_pull.mock_calls))
+
     @mock.patch.object(image_transfer, '_start_transfer')
     @mock.patch('oslo_vmware.rw_handles.VmdkReadHandle')
     def test_copy_stream_optimized_disk(

--- a/oslo_vmware/tests/test_rw_handles.py
+++ b/oslo_vmware/tests/test_rw_handles.py
@@ -417,3 +417,22 @@ class ImageReadHandleTest(base.TestCase):
         for _ in range(0, max_items):
             self.assertEqual(item, handle.read(10))
         self.assertFalse(handle.read(10))
+
+
+class SwiftUrlPullHandleTest(base.TestCase):
+
+    def test_image_swift_url(self):
+        helper = rw_handles.SwiftUrlPullHandle('swift+https://example.com/v1',
+                                               None)
+        self.assertEqual('https://example.com/v1', helper.url())
+
+    def test_image_swift_invalid_url(self):
+        self.assertRaises(ValueError,
+                          rw_handles.SwiftUrlPullHandle,
+                          'https://foo.com',
+                          None)
+
+        self.assertRaises(ValueError,
+                          rw_handles.SwiftUrlPullHandle,
+                          None,
+                          None)

--- a/oslo_vmware/vim_util.py
+++ b/oslo_vmware/vim_util.py
@@ -827,3 +827,19 @@ def storage_placement_spec(client_factory,
     spec.resourcePool = res_pool_ref
     spec.host = host_ref
     return spec
+
+
+def dict_to_kv(client_factory, dict_param):
+    """Converts python dictionary to a vim.KeyValue
+    :param client_factory: the client factory
+    :param dict_param: the dictionary
+    :return: list of KeyValue
+    """
+    def _convert(k, v):
+        kv = client_factory.create("ns0:KeyValue")
+        kv.key = k
+        kv.value = v
+        return kv
+
+    return [_convert(k, v)
+            for k, v in dict_param.items()]

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ eventlet!=0.18.3,!=0.20.1,>=0.18.2 # MIT
 requests>=2.14.2 # Apache-2.0
 urllib3>=1.21.1 # MIT
 oslo.concurrency>=3.26.0 # Apache-2.0
+pyOpenSSL>=17.5.0 # Apache-2.0


### PR DESCRIPTION
Porting from Train to Rocky, so that Nova can use it.

Using HttpNfcLeasePullFromUrls_Task to pull images directly from
the Swift URL.

(cherry picked from commit e8835eb91b4fe893c157f0f4b2e5ecc29a7e1285)