### PR TITLE
Fallback to uploading the image via HttpNfcLease URL

### DIFF
--- a/oslo_vmware/image_transfer.py
+++ b/oslo_vmware/image_transfer.py
@@ -255,10 +255,14 @@ def download_stream_optimized_image(context, timeout_secs, image_service,
             LOG.debug(e)
 
     if url_handle:
-        imported_vm = image_pull_from_url(url_handle, **kwargs)
-        LOG.debug("Downloaded image: %s from image direct URL as a stream "
-                  "optimized file.")
-        return imported_vm
+        try:
+            imported_vm = image_pull_from_url(url_handle, **kwargs)
+            LOG.debug("Downloaded image: %s from image direct URL as a stream "
+                      "optimized file.")
+            return imported_vm
+        except exceptions.VimFaultException as e:
+            LOG.warning("Failed to pull the image directly from URL. Falling "
+                        "back to uploading the image to the HttpNfcLease.", e)
 
     # TODO(vbala) catch specific exceptions raised by download call
     read_iter = image_service.download(context, image_id)


### PR DESCRIPTION
A few vCenters have shown intermitent errors while verifying the
SSL connection to Swift endpoint, thus throwing ocassionally the
vim.fault.SSLVerifyFault exception.
In such unexpected scenarios we can still fallback to transfer
the image by uploading the it to the HttpNfcLease URL.