### PR TITLE
Use vmdk size from .ova files

### DIFF
--- a/oslo_vmware/image_transfer.py
+++ b/oslo_vmware/image_transfer.py
@@ -216,7 +216,8 @@ def _get_vmdk_handle(ova_handle):
                     tar.extractfile(tar_info))
             elif vmdk_name and tar_info.name.startswith(vmdk_name):
                 # Actual file name is <vmdk_name>.XXXXXXX
-                return tar.extractfile(tar_info)
+                return tar.extractfile(tar_info), tar_info.size
+    return None, None
 
 
 def download_stream_optimized_image(context, timeout_secs, image_service,
@@ -269,10 +270,11 @@ def download_stream_optimized_image(context, timeout_secs, image_service,
     read_handle = rw_handles.ImageReadHandle(read_iter)
 
     if container_format == 'ova':
-        read_handle = _get_vmdk_handle(read_handle)
+        read_handle, size = _get_vmdk_handle(read_handle)
         if read_handle is None:
             raise exceptions.ImageTransferException(
                 _("No vmdk found in the OVA image %s.") % image_id)
+        kwargs['image_size'] = size
 
     imported_vm = download_stream_optimized_data(context, timeout_secs,
                                                  read_handle, **kwargs)

--- a/oslo_vmware/tests/test_image_transfer.py
+++ b/oslo_vmware/tests/test_image_transfer.py
@@ -190,7 +190,7 @@ class ImageTransferUtilityTest(base.TestCase):
         tar.extractfile.side_effect = [ovf_handle, vmdk_handle]
 
         ova_handle = mock.sentinel.ova_handle
-        ret = image_transfer._get_vmdk_handle(ova_handle)
+        ret, size = image_transfer._get_vmdk_handle(ova_handle)
 
         self.assertEqual(vmdk_handle, ret)
         tar_open.assert_called_once_with(mode="r|", fileobj=ova_handle)
@@ -208,7 +208,7 @@ class ImageTransferUtilityTest(base.TestCase):
         tar_open.return_value = tar
 
         ova_handle = mock.sentinel.ova_handle
-        ret = image_transfer._get_vmdk_handle(ova_handle)
+        ret, size = image_transfer._get_vmdk_handle(ova_handle)
 
         self.assertIsNone(ret)
         tar_open.assert_called_once_with(mode="r|", fileobj=ova_handle)
@@ -235,10 +235,11 @@ class ImageTransferUtilityTest(base.TestCase):
 
         if container == 'ova':
             if invalid_ova:
-                get_vmdk_handle.return_value = None
+                get_vmdk_handle.return_value = None, None
             else:
                 vmdk_handle = mock.sentinel.vmdk_handle
-                get_vmdk_handle.return_value = vmdk_handle
+                get_vmdk_handle.return_value = (vmdk_handle,
+                                                mock.sentinel.image_size)
 
         imported_vm = mock.sentinel.imported_vm
         download_stream_optimized_data.return_value = imported_vm


### PR DESCRIPTION
Since .ova files contain more than just the .vmdk, the size reported by
glance is not the size of the actual upload. Since olso.vmware now has a
guard against not-finished uploads integrated, we cannot just use the
size from glance. Instead, we switch to using the size of the .vmdk as
reported by the tar file.

Ported from https://github.com/sapcc/nova/commit/5d73d0249bc2d5d72a5e5b0e5282ac8964975a82