### PR TITLE
Revert "Validation of VMDK upload completion"

### DIFF
--- a/oslo_vmware/rw_handles.py
+++ b/oslo_vmware/rw_handles.py
@@ -447,13 +447,7 @@ class VmdkHandle(FileHandle):
         LOG.debug("Lease for %(url)s is in state: %(state)s.",
                   {'url': self._url,
                    'state': state})
-        if self._get_progress() < 100:
-            LOG.error("Aborting lease for %s due to incomplete transfer.",
-                      self._url)
-            self._session.invoke_api(self._session.vim,
-                                     'HttpNfcLeaseAbort',
-                                     self._lease)
-        elif state == 'ready':
+        if state == 'ready':
             LOG.debug("Releasing lease for %s.", self._url)
             self._session.invoke_api(self._session.vim,
                                      'HttpNfcLeaseComplete',
@@ -609,14 +603,7 @@ class VmdkWriteHandle(VmdkHandle):
                                               self._conn, update_progress)
 
     def get_imported_vm(self):
-        """"Get managed object reference of the VM created for import.
-
-        :raises: VimException
-        """
-        if self._get_progress() < 100:
-            excep_msg = _("Incomplete VMDK upload to %s.") % self._url
-            LOG.exception(excep_msg)
-            raise exceptions.ImageTransferException(excep_msg)
+        """"Get managed object reference of the VM created for import."""
         return self._vm_ref
 
     def tell(self):

--- a/oslo_vmware/tests/test_rw_handles.py
+++ b/oslo_vmware/tests/test_rw_handles.py
@@ -168,18 +168,6 @@ class VmdkHandleTest(base.TestCase):
 
         self.assertRaises(exceptions.VimException, handle.update_progress)
 
-    def test_release_lease_incomplete_transfer(self):
-        session = mock.Mock()
-        handle = rw_handles.VmdkHandle(session, None, 'fake-url', None)
-
-        handle._get_progress = mock.Mock(return_value=99)
-        session.invoke_api = mock.Mock()
-        handle._release_lease()
-
-        session.invoke_api.assert_called_with(handle._session.vim,
-                                              'HttpNfcLeaseAbort',
-                                              handle._lease)
-
 
 class VmdkWriteHandleTest(base.TestCase):
     """Tests for VmdkWriteHandle."""
@@ -275,20 +263,8 @@ class VmdkWriteHandleTest(base.TestCase):
 
         session.invoke_api = mock.Mock(
             side_effect=session_invoke_api_side_effect)
-        handle._get_progress = mock.Mock(return_value=100)
         handle.close()
         self.assertEqual(2, session.invoke_api.call_count)
-
-    def test_get_vm_incomplete_transfer(self):
-        session = self._create_mock_session()
-        handle = rw_handles.VmdkWriteHandle(session, '10.1.2.3', 443, 'rp-1',
-                                            'folder-1', None, 100)
-
-        handle._get_progress = mock.Mock(return_value=99)
-        session.invoke_api = mock.Mock()
-
-        self.assertRaises(exceptions.ImageTransferException,
-                          handle.get_imported_vm)
 
 
 class VmdkReadHandleTest(base.TestCase):
@@ -375,7 +351,6 @@ class VmdkReadHandleTest(base.TestCase):
 
         session.invoke_api = mock.Mock(
             side_effect=session_invoke_api_side_effect)
-        handle._get_progress = mock.Mock(return_value=100)
         handle.close()
         self.assertEqual(2, session.invoke_api.call_count)
 

--- a/releasenotes/notes/vmdk-transfer-validation-014d28cc9430e51b.yaml
+++ b/releasenotes/notes/vmdk-transfer-validation-014d28cc9430e51b.yaml
@@ -1,5 +1,0 @@
----
-fixes:
-  - |
-    Incomplete VMDK upload during ImportVApp is falsely marked as successful
-    leading to a corrupted VM.


### PR DESCRIPTION
This reverts commit 5891b57f4f984e5ce61ae6ca9cf9120963d66996.

We need to revert this as it kills restoring backups, because the size is not reached if the volume wasn't completely full at backup time.