### PR TITLE
[SAP] Added set_size() to rw_handles

### DIFF
--- a/oslo_vmware/rw_handles.py
+++ b/oslo_vmware/rw_handles.py
@@ -397,6 +397,10 @@ class VmdkHandle(FileHandle):
         """Get current progress for updating progress to lease."""
         pass
 
+    def set_size(self, vmdk_size):
+        """Method for updating the vmdk size for testing progress completion"""
+        self._vmdk_size = vmdk_size
+
     def update_progress(self):
         """Updates progress to lease.
 


### PR DESCRIPTION
This patch is needed to properly set the internal private attribute of _vmdk_size to the VmdkHandle base class.

When cinder gets a vmdk handle during restore, it needs to specify the actual total size bytes of the vmdk data that has been backed up in order to know when the handle has correctly written all of the data to the vmdk file.  From cinder's backup service the VmdkWriteHandle is wrapped in a eventlet thread Proxy object, which only allows calling methods to set data behind the
Proxy.   Previously Cinder was trying to directly set the
private attribute self._vmdk_size, which was never making it into
the actual VMdkWriteHandle instance itself.

The eventlet Proxy object only allows setting data via wrapping the original object's methods.  Hence the need for creating the set_size() method.

https://eventlet.net/doc/threading.html?highlight=proxThe%20eventlet%20Proxy#eventlet.tpool.Proxy
