### PR TITLE
[wallaby] UrlPullHandle: fix ssl_thumbprint() to return a plain string

### DIFF
--- a/oslo_vmware/rw_handles.py
+++ b/oslo_vmware/rw_handles.py
@@ -854,7 +854,7 @@ class UrlPullHandle(object):
                                            urlinfo.port or 443))
         x509 = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM,
                                                cert)
-        return x509.digest("sha1")
+        return x509.digest("sha1").decode("utf-8")
 
 
 class SwiftUrlPullHandle(UrlPullHandle):


### PR DESCRIPTION
There seems to be a high failure ratio when dowloading images from swift, where download tasks are failing with this error:

	HttpNfcLease.pullFromUrls vim.fault.SSLVerifyFault

It seems to be caused by x509.digest("sha1") returning bytes. While reproducing the issue locally and sending the `sslThumbprint` as a string the image downloads are working well.

Change-Id: I984318989b2e2ea7dacb572646653d9538289d18