### PR TITLE
handle broader Exception when image_pull_from_url fails

### DIFF
--- a/oslo_vmware/image_transfer.py
+++ b/oslo_vmware/image_transfer.py
@@ -259,9 +259,10 @@ def download_stream_optimized_image(context, timeout_secs, image_service,
             LOG.debug("Downloaded image: %s from image direct URL as a stream "
                       "optimized file.")
             return imported_vm
-        except exceptions.VimFaultException as e:
+        except Exception as e:
             LOG.warning("Failed to pull the image directly from URL. Falling "
-                        "back to uploading the image to the HttpNfcLease.", e)
+                        "back to uploading the image to the HttpNfcLease. "
+                        "Error: %s", e)
 
     # TODO(vbala) catch specific exceptions raised by download call
     read_iter = image_service.download(context, image_id)


### PR DESCRIPTION
There can be more than VimFaultException thrown here, i.e. ConnectionRefusedError. By catching `Exception` we make sure that we always fallback to the HttpNfcLease upload, avoiding the volume going to error state.

The log was missing a string placeholder for the exception, causing a "TypeError: not all arguments converted during string formatting".

Change-Id: Ib81eca79210cdbcfe47f50914f1775f07e54de57