### PR TITLE
wait_for_tasks: use property collector to monitor multiple tasks at once

### DIFF
--- a/oslo_vmware/api.py
+++ b/oslo_vmware/api.py
@@ -21,7 +21,10 @@ automatic session re-establishment and retry of API invocations
 in case of connection problems or server API call overload.
 """
 
+from concurrent import futures
 import logging
+import queue
+import threading
 
 from oslo_concurrency import lockutils
 from oslo_context import context
@@ -139,7 +142,8 @@ class VMwareAPISession(object):
                  api_retry_count, task_poll_interval, scheme='https',
                  create_session=True, wsdl_loc=None, pbm_wsdl_loc=None,
                  port=443, cacert=None, insecure=True, pool_size=10,
-                 connection_timeout=None, op_id_prefix='oslo.vmware'):
+                 connection_timeout=None, op_id_prefix='oslo.vmware',
+                 use_property_collector_for_tasks=False):
         """Initializes the API session with given parameters.
 
         :param host: ESX/VC server IP address or host name
@@ -164,6 +168,10 @@ class VMwareAPISession(object):
         :param connection_timeout: Maximum time in seconds to wait for peer to
                                    respond.
         :param op_id_prefix: String prefix for the operation ID.
+        :param use_property_collector_for_tasks: Use WaitForUpdatesEx-based
+                                                 property collector for
+                                                 task monitoring instead
+                                                 of polling
         :raises: VimException, VimFaultException, VimAttributeException,
                  VimSessionOverLoadException
         """
@@ -185,6 +193,19 @@ class VMwareAPISession(object):
         self._pool_size = pool_size
         self._connection_timeout = connection_timeout
         self._op_id_prefix = op_id_prefix
+
+        self._property_collector = None
+        self._property_collector_version = ""
+        self._property_collector_thread = None
+        self._property_collector_running = False
+        self._property_collector_lock = lockutils.ReaderWriterLock()
+
+        self._use_property_collector_for_tasks = (
+            use_property_collector_for_tasks)
+        self._pending_tasks = None
+        # Maps task moref value -> (future, context, filter) for running tasks
+        self._running_tasks = {}
+
         if create_session:
             self._create_session()
 
@@ -259,8 +280,311 @@ class VMwareAPISession(object):
         if self._pbm is not None:
             self._pbm.set_soap_cookie(self._vim.get_http_cookie())
 
+        if self._use_property_collector_for_tasks:
+            self._start_property_collector_thread()
+
+    def _start_property_collector_thread(self):
+        """Start background property collector thread for task monitoring."""
+        with self._property_collector_lock.write_lock():
+            if self._property_collector_running:
+                LOG.debug("Property collector thread already running.")
+                return
+
+            LOG.info("Starting property collector thread for task monitoring.")
+            self._property_collector_running = True
+            self._property_collector_version = ""
+            self._running_tasks = {}
+            self._pending_tasks = queue.Queue()
+
+            try:
+                pc = self.vim.service_content.propertyCollector
+                self._property_collector = self.vim.CreatePropertyCollector(pc)
+                LOG.debug("Created property collector: %s",
+                          vim_util.get_moref_value(self._property_collector))
+            except Exception:
+                LOG.exception("Failed to create property collector.")
+                self._property_collector_running = False
+                raise
+
+            self._property_collector_thread = threading.Thread(
+                target=self._property_collector_loop)
+            self._property_collector_thread.start()
+
+    def _property_collector_loop(self):
+        LOG.debug("Property collector thread started.")
+
+        while self._property_collector_running:
+            with self._property_collector_lock.read_lock():
+                has_tasks = len(self._running_tasks) > 0
+
+            pending_task = None
+            if not has_tasks:
+                LOG.debug("No running tasks, waiting for new tasks...")
+                pending_task = self._pending_tasks.get()
+                # Sentinel for shutdown
+                if pending_task is None:
+                    break
+
+            with self._property_collector_lock.write_lock():
+                if pending_task is not None:
+                    task_value, future, ctx, task_filter = pending_task
+                    self._running_tasks[task_value] = (future, ctx,
+                                                       task_filter)
+                    LOG.debug("Received task %s, moved to running.",
+                              task_value)
+
+                while not self._pending_tasks.empty():
+                    task_data = self._pending_tasks.get_nowait()
+                    if task_data is None:  # Shutdown sentinel
+                        break
+
+                    task_value, future, ctx, task_filter = task_data
+                    self._running_tasks[task_value] = (future, ctx,
+                                                       task_filter)
+
+                if not self._property_collector_running:
+                    break
+
+                self._wait_for_task_updates()
+
+        LOG.debug("Property collector thread stopped.")
+
+    def _wait_for_task_updates(self):
+        """Waits 1 second for task updates using WaitForUpdatesEx."""
+        try:
+            options = self.vim.client.factory.create("ns0:WaitOptions")
+            options.maxWaitSeconds = 1
+
+            update_set = self.vim.WaitForUpdatesEx(
+                self._property_collector,
+                version=self._property_collector_version,
+                options=options)
+
+            if update_set:
+                self._property_collector_version = update_set.version
+                self._process_task_updates(update_set)
+        except exceptions.VimException:
+            LOG.exception("Error in property collector loop, "
+                          "recreating collector.")
+            self._recreate_property_collector()
+
+    def _create_task_filter(self, task_moref):
+        """Create a property filter for a single task.
+
+        :param task_moref: task managed object reference
+        :returns: property filter object
+        """
+        client_factory = self.vim.client.factory
+        property_spec = vim_util.build_property_spec(
+            client_factory,
+            type_='Task',
+            properties_to_collect=['info'])
+
+        object_spec = vim_util.build_object_spec(
+            client_factory,
+            task_moref,
+            [])
+
+        property_filter_spec = vim_util.build_property_filter_spec(
+            client_factory,
+            [property_spec],
+            [object_spec])
+
+        LOG.debug("Creating property filter for task: %s", task_moref.value)
+
+        return self.vim.CreateFilter(
+            self._property_collector,
+            spec=property_filter_spec,
+            partialUpdates=False)
+
+    def _cleanup_task_filter(self, task_value):
+        """Remove task from running list and destroy its property filter.
+
+        :param task_value: task moref value
+        """
+        if task_value in self._running_tasks:
+            _, _, task_filter = self._running_tasks[task_value]
+            del self._running_tasks[task_value]
+            try:
+                self.vim.DestroyPropertyFilter(task_filter)
+            except exceptions.VimException:
+                LOG.warning("Error destroying property filter for task %s",
+                            task_value, exc_info=True)
+
+    def _recreate_property_collector(self):
+        """Recreate the property collector after an error.
+
+        This preserves pending and running tasks and recreates
+        filters for each.
+        """
+        with self._property_collector_lock.write_lock():
+            LOG.info("Recreating property collector.")
+
+            pending_to_add = []
+            while not self._pending_tasks.empty():
+                task_data = self._pending_tasks.get_nowait()
+                if task_data is not None:
+                    task_value, future, ctx, _ = task_data
+                    pending_to_add.append((task_value, future, ctx))
+
+            for task_value, future, ctx in pending_to_add:
+                self._running_tasks[task_value] = (future, ctx, None)
+
+            # Destroy old collector if exists (this also destroys all filters)
+            if self._property_collector:
+                try:
+                    self.vim.DestroyPropertyCollector(self._property_collector)
+                except exceptions.VimException:
+                    LOG.warning("Error destroying old property collector.",
+                                exc_info=True)
+                self._property_collector = None
+
+            pc = self.vim.service_content.propertyCollector
+            self._property_collector = self.vim.CreatePropertyCollector(pc)
+            self._property_collector_version = ""
+
+            tasks_to_recreate = list(self._running_tasks.items())
+            self._running_tasks.clear()
+
+            for task_value, (future, ctx, _) in tasks_to_recreate:
+                try:
+                    task_moref = vim_util.get_moref(task_value, 'Task')
+                    task_filter = self._create_task_filter(task_moref)
+                    self._running_tasks[task_value] = (future, ctx,
+                                                       task_filter)
+                except Exception:
+                    LOG.exception("Failed to recreate filter for task %s",
+                                  task_value)
+                    # Notify waiter of the error
+                    future.set_exception(exceptions.VimException(
+                        "Failed to recreate property filter"))
+
+            LOG.info("Property collector recreated successfully "
+                     "with %d task filters.", len(self._running_tasks))
+
+    def _process_task_updates(self, update_set):
+        """Process task updates from WaitForUpdatesEx.
+
+        :param update_set: UpdateSet from WaitForUpdatesEx
+        """
+        if not update_set.filterSet:
+            return
+
+        for filter_set in update_set.filterSet:
+            if not filter_set.objectSet:
+                continue
+
+            for obj_update in filter_set.objectSet:
+                task_moref = obj_update.obj
+                task_value = vim_util.get_moref_value(task_moref)
+
+                if task_value not in self._running_tasks:
+                    continue
+                future, ctx, _ = self._running_tasks[task_value]
+
+                task_info = None
+                if hasattr(obj_update, 'changeSet'):
+                    for change in obj_update.changeSet:
+                        if (change.name == 'info' and
+                                change.op in ('assign', 'modify')):
+                            task_info = getattr(change, 'val', None)
+                            break
+
+                if not task_info:
+                    continue
+
+                if task_info.state in ['queued', 'running']:
+                    if hasattr(task_info, 'progress'):
+                        task_detail = {'id': task_value}
+                        if getattr(task_info, 'name', None):
+                            task_detail['name'] = task_info.name
+                        LOG.debug("Task: %(task)s progress is %(progress)s%%.",
+                                  {'task': task_detail,
+                                   'progress': task_info.progress})
+                elif task_info.state == 'success':
+                    task_detail = {'id': task_value}
+                    if getattr(task_info, 'name', None):
+                        task_detail['name'] = task_info.name
+                    complete_time = getattr(task_info, 'completeTime', None)
+                    if complete_time:
+                        duration = complete_time - task_info.queueTime
+                        task_detail['duration_secs'] = duration.total_seconds()
+                    LOG.debug("Task: %s completed successfully.", task_detail)
+
+                    self._cleanup_task_filter(task_value)
+                    if ctx:
+                        ctx.update_store()
+                    future.set_result(task_info)
+                else:
+                    LOG.debug("Task: %s entered state: %s",
+                              task_value, task_info.state)
+
+                    self._cleanup_task_filter(task_value)
+                    if ctx:
+                        ctx.update_store()
+                    try:
+                        exception = exceptions.translate_fault(task_info.error)
+                        future.set_exception(exception)
+                    except Exception as e:
+                        future.set_exception(e)
+
+    def _stop_property_collector_thread(self):
+        """Stop the background property collector thread."""
+        with self._property_collector_lock.write_lock():
+            if not self._property_collector_running:
+                return
+
+            LOG.info("Stopping property collector thread.")
+            self._property_collector_running = False
+            # Send sentinel to wake up the thread if it's waiting
+            self._pending_tasks.put(None)
+
+        if self._property_collector_thread:
+            self._property_collector_thread.join()
+            self._property_collector_thread = None
+
+        # Clean up property collector
+        with self._property_collector_lock.write_lock():
+            if self._property_collector:
+                try:
+                    self.vim.DestroyPropertyCollector(self._property_collector)
+                except exceptions.VimException:
+                    LOG.warning("Error destroying property collector.",
+                                exc_info=True)
+                self._property_collector = None
+                self._property_collector_filter = None
+
+            # Notify any remaining waiters in pending queue
+            while not self._pending_tasks.empty():
+                task_data = self._pending_tasks.get_nowait()
+                if task_data is not None:
+                    _, future, _, _ = task_data
+                    try:
+                        future.set_exception(
+                            exceptions.VimException(
+                                _("Property collector stopped while waiting")))
+                    except futures.InvalidStateError:
+                        pass
+
+            # Notify any remaining waiters in running tasks
+            for task_value, (future, ctx, _) in self._running_tasks.items():
+                try:
+                    future.set_exception(
+                        exceptions.VimException(
+                            _("Property collector stopped while waiting for "
+                              "task %s") % task_value))
+                except futures.InvalidStateError:
+                    pass
+            self._running_tasks = {}
+
+        LOG.info("Property collector thread stopped.")
+
+    @lockutils.synchronized('oslo_vmware_api_lock')
     def logout(self):
         """Log out and terminate the current session."""
+        if self._use_property_collector_for_tasks:
+            self._stop_property_collector_thread()
+
         if self._session_id:
             LOG.info("Logging out and terminating the current session "
                      "with ID = %s.",
@@ -385,6 +709,49 @@ class VMwareAPISession(object):
         The task is polled until it is done. The method returns the task
         information upon successful completion. In case of any error,
         appropriate exception is raised.
+
+        :param task: managed object reference of the task
+        :returns: task info upon successful completion of the task
+        :raises: VimException, VimFaultException, VimAttributeException,
+                 VimSessionOverLoadException, VimConnectionException
+        """
+        if self._use_property_collector_for_tasks:
+            return self._wait_for_task_with_property_collector(task)
+        else:
+            return self._wait_for_task_with_polling(task)
+
+    def _wait_for_task_with_property_collector(self, task):
+        """Wait for task using centralized property collector.
+
+        Creates a dedicated property filter for this task and adds
+        it to the queue.
+
+        :param task: managed object reference of the task
+        :returns: task info upon successful completion of the task
+        :raises: VimException, VimFaultException, VimAttributeException,
+                 VimSessionOverLoadException, VimConnectionException
+        """
+        ctx = context.get_current()
+        future = futures.Future()
+        task_value = vim_util.get_moref_value(task)
+
+        # The write lock is held by the WaitForUpdatesEx, making
+        # sure we don't lose any tasks
+        with self._property_collector_lock.read_lock():
+            if not self._property_collector_running:
+                raise exceptions.VimException(
+                    _("Property collector was stopped."))
+            task_filter = self._create_task_filter(task)
+            self._pending_tasks.put((task_value, future, ctx, task_filter))
+
+        try:
+            return future.result()
+        finally:
+            with self._property_collector_lock.write_lock():
+                self._cleanup_task_filter(task_value)
+
+    def _wait_for_task_with_polling(self, task):
+        """Wait for task using traditional polling approach.
 
         :param task: managed object reference of the task
         :returns: task info upon successful completion of the task


### PR DESCRIPTION
The current wait_for_task implementation polls each task individually by creating separate SOAP requests repeatedly. This is inefficient when a service manages many concurrent tasks, as each poll generates CPU load and network traffic on both the client and vCenter server.

This change implements a centralized property collector that uses VMware's WaitForUpdatesEx API to monitor multiple tasks efficiently over a single persistent socket connection.

- Runs a background thread that manages the property collector and processes task updates asynchronously
- Uses WaitForUpdatesEx to wait for task state changes instead of polling, reducing SOAP requests.
- Maintains 1 TaskFilter per task (create/delete).
- Automatically recreates the property collector on errors

The feature is opt-in via the use_property_collector_for_tasks constructor parameter (default: False).

The wait_for_task() method signature remains unchanged, making the optimization transparent to callers.

Change-Id: Iebffb74a53a7fa8d679daeb486b844fdea5b5113